### PR TITLE
Update the version of transformer in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ tenacity
 sentencepiece
 tiktoken
 loguru
-transformers>=4.36.0
+transformers>=4.37.0
 peft>=0.4.0
 accelerate>=0.20.3
 sentence-transformers


### PR DESCRIPTION
为了适应新模型 Qwen1.5 
This is a must because `transformers` integrated Qwen2 codes since `4.37.0`.