### PR TITLE
streamlit 1.32.2 版本新api适配

### DIFF
--- a/streamlit-demo/streamlit_gallery/components/doc_chat/streamlit_app.py
+++ b/streamlit-demo/streamlit_gallery/components/doc_chat/streamlit_app.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from openai import OpenAI
 
 import streamlit as st
-from langchain.embeddings import OpenAIEmbeddings
+from langchain_community.embeddings import OpenAIEmbeddings
 
 from .utils import FaissDocServer, Embeddings, DOCQA_PROMPT
 

--- a/streamlit-demo/streamlit_gallery/components/doc_chat/utils.py
+++ b/streamlit-demo/streamlit_gallery/components/doc_chat/utils.py
@@ -2,7 +2,7 @@ import importlib
 import os
 from typing import List
 
-from langchain.vectorstores import FAISS
+from langchain_community.vectorstores import FAISS
 from loguru import logger
 from sentence_transformers import SentenceTransformer
 

--- a/streamlit-demo/streamlit_gallery/components/search_chat/streamlit_app.py
+++ b/streamlit-demo/streamlit_gallery/components/search_chat/streamlit_app.py
@@ -1,7 +1,7 @@
 import os
 
 import streamlit as st
-from langchain.utilities import SerpAPIWrapper
+from langchain_community.utilities import SerpAPIWrapper
 from openai import OpenAI
 
 PROMPT_TEMPLATE = """<指令>根据已知信息，简洁和专业的来回答问题。如果无法从中得到答案，请说 “根据已知信息无法回答该问题”，不允许在答案中添加编造成分，答案请使用中文。 </指令>

--- a/streamlit-demo/streamlit_gallery/utils/page.py
+++ b/streamlit-demo/streamlit_gallery/utils/page.py
@@ -24,8 +24,8 @@ class PageGroup:
 
     @property
     def selected(self):
-        params = st.experimental_get_query_params()
-        return params[self._param][0] if self._param in params else self._default
+        params = st.query_params.to_dict()
+        return params[self._param] if self._param in params else self._default
 
     def item(self, label: str, callback: Callable, default=False) -> None:
         self._backup = None
@@ -51,7 +51,7 @@ class PageGroup:
             st.title("🤷 404 Not Found")
 
     def _on_change(self, page: str) -> None:
-        params = st.experimental_get_query_params()
+        params = st.query_params.to_dict()
 
         if self._backup is None:
             if self._param in params:
@@ -60,7 +60,8 @@ class PageGroup:
         else:
             params[self._param] = [self._backup]
 
-        st.experimental_set_query_params(**params)
+        for key in params:
+            st.query_params[key] = params[key]
         st.session_state.messages = []
 
     def _normalize_label(self, label: str) -> str:


### PR DESCRIPTION
streamlit 1.32.2 版本开始，experimental_query_params 的api开始被提醒要被替换（马上会删除）

该提交适配了新的api，消除了页面上的提示。

langchain自0.1.12版本开始，langchain 包名被替换为 langchain_community，该提交也进行了更改

相关issue: https://github.com/xusenlinzy/api-for-open-llm/issues/221