### PR TITLE
fix glm4 chat forward error

### DIFF
--- a/api/templates/glm.py
+++ b/api/templates/glm.py
@@ -493,7 +493,7 @@ class ChatGLM4ChatTemplate(ChatTemplate):
             messages,
             add_generation_prompt=True,
             tokenize=True,
-        )[0]
+        )
 
     def parse_assistant_response(
         self,


### PR DESCRIPTION
apply_chat_template returns a one-dimensional array, [0] got a value instead of an array, causing exceptions in subsequent len ​​operations.